### PR TITLE
Use model_name instead of the name of a model class

### DIFF
--- a/lib/generators/dry_crud/templates/app/helpers/standard_helper.rb
+++ b/lib/generators/dry_crud/templates/app/helpers/standard_helper.rb
@@ -27,7 +27,7 @@ module StandardHelper
   # If the value is an associated model, renders the label of this object.
   # Otherwise, calls format_type.
   def format_attr(obj, attr)
-    format_type_attr_method = :"format_#{obj.class.name.underscore}_#{attr.to_s}"
+    format_type_attr_method = :"format_#{obj.class.model_name.underscore}_#{attr.to_s}"
     format_attr_method = :"format_#{attr.to_s}"
     if respond_to?(format_type_attr_method)
       send(format_type_attr_method, obj)
@@ -260,7 +260,7 @@ module StandardHelper
 
   # Returns true if no link should be created when formatting the given association.
   def no_assoc_link?(assoc, val)
-    !respond_to?("#{val.class.name.underscore}_path".to_sym)
+    !respond_to?("#{val.class.model_name.underscore}_path".to_sym)
   end
 
   # Returns the association proxy for the given attribute. The attr parameter


### PR DESCRIPTION
Howdie,

I think it would be better to use `class.model_name` insteaed of `model_name` as this makes things more in line with how it is done by rails + it makes things more flexible, especially while using STI.

More detailed description in the commit message:

ActionPack in general uses model_name of a model class to determine
its links. We should also do that in our helpers, so we follow what
Rails does in general.

Also using model_name helps us in generating links for models, that
use STI, but should be available all under the same link. As
described in [1].
Using model_name even let us keep the flexibility to selectively use
different paths for a few subclasses of the main STI-model, by re-
implementing the model_name class.

[1] http://code.alexreisner.com/articles/single-table-inheritance-in-rails.html
