### PR TITLE
Ruby 1.8.7 compability

### DIFF
--- a/lib/generators/dry_crud/dry_crud_generator.rb
+++ b/lib/generators/dry_crud/dry_crud_generator.rb
@@ -16,7 +16,7 @@ class DryCrudGenerator < Rails::Generators::Base
     Dir.chdir(self.class.source_root) do
       Dir.glob(File.join('**', '**')).sort.each do |file_source|
       	if !File.directory?(file_source) && 
-      	   !file_source.ends_with?(exclude) && 
+      	   !file_source.end_with?(exclude) && 
       	   file_source != 'INSTALL'
         	copy_file(file_source) 
         end


### PR DESCRIPTION
There is no `ends_with?` in ruby 1.8.7
