### PR TITLE
Be more explicit in error-message

### DIFF
--- a/lib/generators/dry_crud/templates/test/support/crud_controller_test_helper.rb
+++ b/lib/generators/dry_crud/templates/test/support/crud_controller_test_helper.rb
@@ -177,12 +177,12 @@ module CrudControllerTestHelper
 
   # Test object used in several tests.
   def test_entry
-    raise 'Implement this method in your test class'
+    raise 'Implement the method "test_entry" in your test class'
   end
 
   # Attribute hash used in several tests.
   def test_entry_attrs
-    raise 'Implement this method in your test class'
+    raise 'Implement the method "test_entry_attrs" in your test class'
   end
 
   # Attribute hash used in edit/update tests.


### PR DESCRIPTION
As a developer reading the error-message before the stack-trace
I want to have all relevant information in the error-message
In order to reduce the mental overhead of following the stack-trace.